### PR TITLE
fix: [ZNO-2072] Fix problem when libGL.so.1: cannot open shared object

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,9 @@ RUN mkdir -p ${PYTHONPATH} superset/static superset-frontend apache_superset.egg
         libpq-dev \
         libecpg-dev \
         libldap2-dev \
+        ffmpeg \
+        libsm6 \
+        libxext6 \
     && apt-get autoremove -yqq --purge && rm -rf /var/lib/apt/lists/* /var/[log,tmp]/* /tmp/* && apt-get clean \
     && touch superset/static/version_info.json \
     && chown -R superset:superset ./*


### PR DESCRIPTION
This PR is going to fix the problem when ImportError: libGL.so.1: cannot open shared object file: No such file or directory.

Task https://youtrack.raccoongang.com/issue/ZNO-2072