### PR TITLE
fix: [ZNO-2098] Slugifies unicode name to generate download headers

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -232,6 +232,10 @@ parsedatetime==2.6
     # via apache-superset
 pdf2docx==0.5.6
     # via apache-superset
+unidecode==1.0.22
+    # via apache-superset
+python-slugify==v8.0.1
+    # via apache-superset
 pgsanity==0.2.9
     # via apache-superset
 polyline==2.0.0

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -46,8 +46,10 @@ from flask_babel import get_locale, gettext as __, lazy_gettext as _
 from flask_jwt_extended.exceptions import NoAuthorizationError
 from flask_wtf.csrf import CSRFError
 from flask_wtf.form import FlaskForm
+from slugify import slugify
 from sqlalchemy import exc
 from sqlalchemy.orm import Query
+from unidecode import unidecode
 from werkzeug.exceptions import HTTPException
 from wtforms import Form
 from wtforms.fields.core import Field, UnboundField
@@ -184,7 +186,11 @@ def data_payload_response(payload_json: str, has_error: bool = False) -> FlaskRe
 def generate_download_headers(
     extension: str, filename: Optional[str] = None
 ) -> dict[str, Any]:
-    filename = filename if filename else datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = (
+        slugify(unidecode(filename))
+        if filename
+        else datetime.now().strftime("%Y%m%d_%H%M%S")
+    )
     content_disp = f"attachment; filename={filename}.{extension}"
     headers = {"Content-Disposition": content_disp}
     return headers


### PR DESCRIPTION
## Summary

This PR fixes the problem when downloading the dashboard in PDF or Word format does not work if the name of the dashboard is specified in Ukrainian.

Task https://youtrack.raccoongang.com/issue/ZNO-2098