### PR TITLE
chore: [ZNO-3747] The Dockerfile for the `superset-pdf-report` service was updated to use `node:16-bullseye`, resolving issues with outdated Debian Buster repositories

### DIFF
--- a/superset-pdf-report/Dockerfile
+++ b/superset-pdf-report/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile uses multi-stage build to customize DEV and PROD images:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM node:16 AS base
+FROM node:16-bullseye AS base
 
 LABEL maintainer="nikolay.borovenskiy@raccoongang.com"
 LABEL vendor="Prozori solutions"
@@ -12,13 +12,13 @@ LABEL vendor="Prozori solutions"
 # of Chromium that Puppeteer
 # installs, work.
 RUN apt-get update \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 \
+    && apt-get install -y chromium fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
+
+# Set Puppeteer to use the installed Chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 
 ## It's a good idea to use dumb-init to help prevent zombie chrome processes.


### PR DESCRIPTION
This PR adds to the Dockerfile for the `superset-pdf-report` service was updated to use `node:16-bullseye`, resolving issues with outdated Debian Buster repositories. The installation method for Chromium was modified for better compatibility, leading to a successful Docker image build. There were previous failures related to missing repositories and package installation, but these have been resolved.